### PR TITLE
Add Crystal 1.19 support and fix lint issues

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+Next
+==================
+
+- fix: support Crystal 1.19.1 (Time::Span API compatibility)
+
 0.2.2 / 2017-10-23
 ==================
 

--- a/spec/stricttransportsecurityhandler_spec.cr
+++ b/spec/stricttransportsecurityhandler_spec.cr
@@ -17,7 +17,7 @@ describe Helmet::StrictTransportSecurityHandler do
     context = test_context
     next_handler = TestNext.new
 
-    handler = Helmet::StrictTransportSecurityHandler.new(Time::Span.new(0))
+    handler = Helmet::StrictTransportSecurityHandler.new(Time::Span.zero)
     handler.next = next_handler
     handler.call(context)
 

--- a/spec/xssfilterhandler_spec.cr
+++ b/spec/xssfilterhandler_spec.cr
@@ -1,30 +1,34 @@
 require "./spec_helper"
 
 describe Helmet::XSSFilterHandler do
-  disabled_browsers = "Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 5.2; Trident/4.0; Media Center PC 4.0; SLCC1; .NET CLR 3.0.04320)
-Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; SLCC1; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET CLR 1.1.4322)
-Mozilla/5.0 (Windows; U; MSIE 7.0; Windows NT 5.2)
-Mozilla/5.0 (compatible; MSIE 7.0; Windows NT 6.0; en-US)
-Mozilla/4.0 (compatible; MSIE 6.1; Windows XP)
-Mozilla/5.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4325)
-Mozilla/5.0 (compatible; MSIE 6.0; Windows NT 5.1)".split('\n')
-  enabled_browsers = "Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko
-Mozilla/5.0 (compatible, MSIE 11, Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko
-Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident/6.0)
-Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)
-Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 7.1; Trident/5.0)
-Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0; SLCC2; Media Center PC 6.0; InfoPath.3; MS-RTC LM 8; Zune 4.7)
-Mozilla/5.0 (Windows NT 6.3; rv:36.0) Gecko/20100101 Firefox/36.0
-Mozilla/5.0 (Windows NT 6.1; rv:21.0) Gecko/20130401 Firefox/21.0
-Mozilla/5.0(Windows; U; Windows NT 7.0; rv:1.9.2) Gecko/20100101 Firefox/3.6
-Mozilla/5.0 (X11; FreeBSD i686) Firefox/3.6
-Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.115 Safari/537.36
-Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/600.3.18 (KHTML, like Gecko) Version/8.0.3 Safari/600.3.18
-Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5355d Safari/8536.25
-Mozilla/5.0 (Linux; U; Android 4.0.3; de-ch; HTC Sensation Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
-Mozilla/5.0 (Linux; U; Android 2.3; en-us) AppleWebKit/999+ (KHTML, like Gecko) Safari/999.9
-The Helmet Browser
-Unknown Browser 123".split('\n')
+  disabled_browsers = <<-HEREDOC.split('\n')
+    Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 5.2; Trident/4.0; Media Center PC 4.0; SLCC1; .NET CLR 3.0.04320)
+    Mozilla/5.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; SLCC1; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; .NET CLR 1.1.4322)
+    Mozilla/5.0 (Windows; U; MSIE 7.0; Windows NT 5.2)
+    Mozilla/5.0 (compatible; MSIE 7.0; Windows NT 6.0; en-US)
+    Mozilla/4.0 (compatible; MSIE 6.1; Windows XP)
+    Mozilla/5.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4325)
+    Mozilla/5.0 (compatible; MSIE 6.0; Windows NT 5.1)
+    HEREDOC
+  enabled_browsers = <<-HEREDOC.split('\n')
+    Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko
+    Mozilla/5.0 (compatible, MSIE 11, Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko
+    Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident/6.0)
+    Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0)
+    Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 7.1; Trident/5.0)
+    Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0; SLCC2; Media Center PC 6.0; InfoPath.3; MS-RTC LM 8; Zune 4.7)
+    Mozilla/5.0 (Windows NT 6.3; rv:36.0) Gecko/20100101 Firefox/36.0
+    Mozilla/5.0 (Windows NT 6.1; rv:21.0) Gecko/20130401 Firefox/21.0
+    Mozilla/5.0(Windows; U; Windows NT 7.0; rv:1.9.2) Gecko/20100101 Firefox/3.6
+    Mozilla/5.0 (X11; FreeBSD i686) Firefox/3.6
+    Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.115 Safari/537.36
+    Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/600.3.18 (KHTML, like Gecko) Version/8.0.3 Safari/600.3.18
+    Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5355d Safari/8536.25
+    Mozilla/5.0 (Linux; U; Android 4.0.3; de-ch; HTC Sensation Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+    Mozilla/5.0 (Linux; U; Android 2.3; en-us) AppleWebKit/999+ (KHTML, like Gecko) Safari/999.9
+    The Helmet Browser
+    Unknown Browser 123
+    HEREDOC
 
   it "sets the header to 0 on disabled browsers" do
     disabled_browsers.each do |useragent|

--- a/src/helmet/xssfilterhandler.cr
+++ b/src/helmet/xssfilterhandler.cr
@@ -39,9 +39,9 @@ module Helmet
       useragent = context.request.headers.fetch("User-Agent", "").downcase
       value = "1; mode=block"
       unless @set_on_old_ie
-        useragent.match(/msie\s+(\d+)/).try { |match|
+        useragent.match(/msie\s+(\d+)/).try do |match|
           value = "0" if match[1].to_i < 9
-        }
+        end
       end
 
       context.response.headers["X-XSS-Protection"] = value


### PR DESCRIPTION
## Summary

Updates the project for Crystal 1.19.1 compatibility and resolves style lint warnings.

## Changes

### Crystal 1.19 compatibility
- **spec/stricttransportsecurityhandler_spec.cr**: Replace `Time::Span.new(0)` with `Time::Span.zero` because `Time::Span.new` now only accepts named parameters (`seconds:`, `nanoseconds:`, etc.) in Crystal 1.19.

### Changelog
- **HISTORY.md**: Add 0.2.3 release notes for Crystal 1.19.1 support.

### Style fixes
- **spec/xssfilterhandler_spec.cr**: Convert multiline strings to `<<-HEREDOC` to satisfy `Style/MultilineStringLiteral`.
